### PR TITLE
fix(#7): add author/lang metadata and cover fixes

### DIFF
--- a/posts/2026-02-02-ai-blog-series-1-start.ko.md
+++ b/posts/2026-02-02-ai-blog-series-1-start.ko.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [ai-blog-series, opencode, blog, content-creation, hugo, cloudflare]
 draft: false
 summary: "왜 촬영감독의 이름을 블로그 이름으로 택했는지, 왜 Hugo와 Cloudflare를 선택했는지, 그리고 AI 대화를 수확하는 시스템을 구축한 이유를 담았다."
+lang: ko
 series: ["AI와 블로그 만들기"]
 cover:
   image: "/cover-series-1.png"

--- a/posts/2026-02-02-ai-blog-series-1-start.md
+++ b/posts/2026-02-02-ai-blog-series-1-start.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [ai-blog-series, opencode, blog, content-creation, hugo, cloudflare]
 draft: false
 summary: "Why I named this blog after a cinematographer, chose Hugo and Cloudflare, and built a system to harvest AI conversations into posts."
+lang: en
 series: ["Building a Blog with AI"]
 cover:
   image: "/cover-series-1.png"

--- a/posts/2026-02-03-ai-agent-security-audit-en.md
+++ b/posts/2026-02-03-ai-agent-security-audit-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The AI Agent Security Audit Checklist: 6 Critical Areas You Can't Ignore"
 date: 2026-02-03
+author: Raoul
 categories: [security, ai-agents]
 tags: [security-audit, ai-agents, devops, checklist, automation]
 draft: false

--- a/posts/2026-02-03-ai-agent-security-audit-ko.md
+++ b/posts/2026-02-03-ai-agent-security-audit-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "AI 에이전트 보안 감사 체크리스트: 반드시 확인해야 할 6가지 영역"
 date: 2026-02-03
+author: Raoul
 categories: [security, ai-agents]
 tags: [security-audit, ai-agents, devops, checklist, automation]
 draft: false

--- a/posts/2026-02-03-ai-blog-series-2-failures.ko.md
+++ b/posts/2026-02-03-ai-blog-series-2-failures.ko.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [ai-blog-series, debugging, bash, symlink, lessons-learned]
 draft: false
 summary: "블로그를 만들면서 겪은 세 가지 구체적인 실패와 그로부터 배운 교훈들을 공유합니다."
+lang: ko
 series: ["AI와 블로그 만들기"]
 cover:
   image: "/cover-series-2.png"

--- a/posts/2026-02-03-ai-blog-series-2-failures.md
+++ b/posts/2026-02-03-ai-blog-series-2-failures.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [ai-blog-series, debugging, bash, symlink, lessons-learned]
 draft: false
 summary: "Why I log my mistakes, and three concrete failures from building this blog."
+lang: en
 series: ["Building a Blog with AI"]
 cover:
   image: "/cover-series-2.png"

--- a/posts/2026-02-03-always-on-skill-injection-en.md
+++ b/posts/2026-02-03-always-on-skill-injection-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Always-On Skills: Making AI Agent Behaviors Persistent"
 date: 2026-02-03
+author: Raoul
 categories: [ai-agents, configuration]
 tags: [opencode, skills, automation, configuration]
 draft: false

--- a/posts/2026-02-03-always-on-skill-injection-ko.md
+++ b/posts/2026-02-03-always-on-skill-injection-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "항상 켜진 스킬: AI 에이전트 행동을 지속적으로 만들기"
 date: 2026-02-03
+author: Raoul
 categories: [ai-agents, configuration]
 tags: [opencode, skills, automation, configuration]
 draft: false

--- a/posts/2026-02-03-auth-artifact-mismatch-en.md
+++ b/posts/2026-02-03-auth-artifact-mismatch-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Shell vs TypeScript: When Auth Artifacts Don't Match"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, integration]
 tags: [playwright, authentication, shell-scripts, typescript, cross-language]
 draft: false

--- a/posts/2026-02-03-auth-artifact-mismatch-ko.md
+++ b/posts/2026-02-03-auth-artifact-mismatch-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Shell vs TypeScript: 인증 아티팩트가 맞지 않을 때"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, integration]
 tags: [playwright, authentication, shell-scripts, typescript, cross-language]
 draft: false

--- a/posts/2026-02-03-autonomous-companion-architecture-en.md
+++ b/posts/2026-02-03-autonomous-companion-architecture-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Building an Autonomous AI Companion: A Cost-Aware Architecture"
 date: 2026-02-03
+author: Raoul
 categories: [architecture, AI]
 tags: [ai-agents, token-optimization, autonomous-systems, cost-optimization]
 draft: false

--- a/posts/2026-02-03-autonomous-companion-architecture-ko.md
+++ b/posts/2026-02-03-autonomous-companion-architecture-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "자율 AI 컴패니언 구축하기: 비용 인식 아키텍처"
 date: 2026-02-03
+author: Raoul
 categories: [architecture, AI]
 tags: [ai-agents, token-optimization, autonomous-systems, cost-optimization]
 draft: false

--- a/posts/2026-02-03-cloudflare-wrong-repo-en.md
+++ b/posts/2026-02-03-cloudflare-wrong-repo-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The Wrong Repo Mystery: When Cloudflare Builds From the Past"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, devops]
 tags: [cloudflare, deployment, ci-cd, git, repository]
 draft: false

--- a/posts/2026-02-03-cloudflare-wrong-repo-ko.md
+++ b/posts/2026-02-03-cloudflare-wrong-repo-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "잘못된 레포 미스터리: Cloudflare가 과거에서 빌드할 때"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, devops]
 tags: [cloudflare, deployment, ci-cd, git, repository]
 draft: false

--- a/posts/2026-02-03-docker-sandbox-testing-en.md
+++ b/posts/2026-02-03-docker-sandbox-testing-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Safe Testing for Docker-Sandboxed AI Bots"
 date: 2026-02-03
+author: Raoul
 categories: [devops, security]
 tags: [docker, sandbox, testing, ai-bots, safety]
 draft: false

--- a/posts/2026-02-03-docker-sandbox-testing-ko.md
+++ b/posts/2026-02-03-docker-sandbox-testing-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Docker 샌드박스 AI 봇을 위한 안전한 테스팅"
 date: 2026-02-03
+author: Raoul
 categories: [devops, security]
 tags: [docker, sandbox, testing, ai-bots, safety]
 draft: false

--- a/posts/2026-02-03-git-worktree-parallel-agents-en.md
+++ b/posts/2026-02-03-git-worktree-parallel-agents-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Git Worktrees: Running Multiple AI Agents on the Same Repo"
 date: 2026-02-03
+author: Raoul
 categories: [workflow, git]
 tags: [git, worktree, ai-agents, parallel-work, multi-session]
 draft: false

--- a/posts/2026-02-03-git-worktree-parallel-agents-ko.md
+++ b/posts/2026-02-03-git-worktree-parallel-agents-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Git Worktree: 같은 저장소에서 여러 AI 에이전트 동시 실행하기"
 date: 2026-02-03
+author: Raoul
 categories: [workflow, git]
 tags: [git, worktree, ai-agents, parallel-work, multi-session]
 draft: false

--- a/posts/2026-02-03-korean-haerache-style-en.md
+++ b/posts/2026-02-03-korean-haerache-style-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Why I Write Korean Tech Blogs in Haerache Style"
 date: 2026-02-03
+author: Raoul
 categories: [writing, language]
 tags: [korean, writing-style, localization, tech-blogs]
 draft: false

--- a/posts/2026-02-03-korean-haerache-style-ko.md
+++ b/posts/2026-02-03-korean-haerache-style-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "왜 기술 블로그를 해라체로 쓰는가"
 date: 2026-02-03
+author: Raoul
 categories: [writing, language]
 tags: [korean, writing-style, localization, tech-blogs]
 draft: false

--- a/posts/2026-02-03-lenis-scrollsnap-conflict-en.md
+++ b/posts/2026-02-03-lenis-scrollsnap-conflict-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Why Lenis Broke My Scroll-Snap (And How I Fixed It)"
 date: 2026-02-03
+author: Raoul
 categories: [frontend, debugging]
 tags: [lenis, scroll-snap, css, javascript, gotcha]
 draft: false

--- a/posts/2026-02-03-lenis-scrollsnap-conflict-ko.md
+++ b/posts/2026-02-03-lenis-scrollsnap-conflict-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Lenis가 Scroll-Snap을 망가뜨린 이유 (그리고 수정 방법)"
 date: 2026-02-03
+author: Raoul
 categories: [frontend, debugging]
 tags: [lenis, scroll-snap, css, javascript, gotcha]
 draft: false

--- a/posts/2026-02-03-local-first-model-routing-en.md
+++ b/posts/2026-02-03-local-first-model-routing-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Local-First Model Routing: Stop Wasting API Calls"
 date: 2026-02-03
+author: Raoul
 categories: [architecture, AI]
 tags: [llm, routing, ollama, cost-optimization, apple-silicon]
 draft: false

--- a/posts/2026-02-03-local-first-model-routing-ko.md
+++ b/posts/2026-02-03-local-first-model-routing-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "로컬 우선 모델 라우팅: API 낭비를 멈춰라"
 date: 2026-02-03
+author: Raoul
 categories: [architecture, AI]
 tags: [llm, routing, ollama, cost-optimization, apple-silicon]
 draft: false

--- a/posts/2026-02-03-local-path-privacy-leak-en.md
+++ b/posts/2026-02-03-local-path-privacy-leak-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Your Blog Posts Are Leaking Your Username: Local Path Privacy"
 date: 2026-02-03
+author: Raoul
 categories: [security, content]
 tags: [privacy, security, blogging, content-review, devops]
 draft: false

--- a/posts/2026-02-03-local-path-privacy-leak-ko.md
+++ b/posts/2026-02-03-local-path-privacy-leak-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "블로그 포스트가 유저네임을 노출한다: 로컬 경로 프라이버시"
 date: 2026-02-03
+author: Raoul
 categories: [security, content]
 tags: [privacy, security, blogging, content-review, devops]
 draft: false

--- a/posts/2026-02-03-macos-sysadminctl-homedir-en.md
+++ b/posts/2026-02-03-macos-sysadminctl-homedir-en.md
@@ -1,6 +1,7 @@
 ---
 title: "macOS sysadminctl Gotcha: Home Directory Not Created"
 date: 2026-02-03
+author: Raoul
 categories: [macos, sysadmin]
 tags: [macos, service-account, sysadminctl, gotcha]
 draft: false

--- a/posts/2026-02-03-macos-sysadminctl-homedir-ko.md
+++ b/posts/2026-02-03-macos-sysadminctl-homedir-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "macOS sysadminctl 함정: 홈 디렉토리가 생성되지 않는다"
 date: 2026-02-03
+author: Raoul
 categories: [macos, sysadmin]
 tags: [macos, service-account, sysadminctl, gotcha]
 draft: false

--- a/posts/2026-02-03-meme-sourcing-pipeline-en.md
+++ b/posts/2026-02-03-meme-sourcing-pipeline-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Why I Source Memes Instead of Generating Them"
 date: 2026-02-03
+author: Raoul
 categories: [content, opinion]
 tags: [memes, content-creation, ai-images, visual-content]
 draft: false

--- a/posts/2026-02-03-meme-sourcing-pipeline-ko.md
+++ b/posts/2026-02-03-meme-sourcing-pipeline-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "왜 밈을 생성하는 대신 소싱하는가"
 date: 2026-02-03
+author: Raoul
 categories: [content, opinion]
 tags: [memes, content-creation, ai-images, visual-content]
 draft: false

--- a/posts/2026-02-03-model-id-exact-match-en.md
+++ b/posts/2026-02-03-model-id-exact-match-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Model ID Must Match Exactly: The Provider Lookup Gotcha"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, configuration]
 tags: [opencode, llm, model-configuration, api]
 draft: false

--- a/posts/2026-02-03-model-id-exact-match-ko.md
+++ b/posts/2026-02-03-model-id-exact-match-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "모델 ID는 정확히 일치해야 한다: Provider Lookup 함정"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, configuration]
 tags: [opencode, llm, model-configuration, api]
 draft: false

--- a/posts/2026-02-03-native-dialog-lightbox-en.md
+++ b/posts/2026-02-03-native-dialog-lightbox-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Ditch Your Lightbox Library: Native Dialog Does It Better"
 date: 2026-02-03
+author: Raoul
 categories: [frontend, html5]
 tags: [dialog, lightbox, html5, accessibility, no-javascript]
 draft: false

--- a/posts/2026-02-03-native-dialog-lightbox-ko.md
+++ b/posts/2026-02-03-native-dialog-lightbox-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "라이트박스 라이브러리를 버려라: 네이티브 Dialog가 더 낫다"
 date: 2026-02-03
+author: Raoul
 categories: [frontend, html5]
 tags: [dialog, lightbox, html5, accessibility, no-javascript]
 draft: false

--- a/posts/2026-02-03-opencode-mcp-config-schema-en.md
+++ b/posts/2026-02-03-opencode-mcp-config-schema-en.md
@@ -1,6 +1,7 @@
 ---
 title: "OpenCode vs Claude Desktop: The MCP Config Schema Trap"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, configuration]
 tags: [opencode, mcp, claude-desktop, schema, configuration]
 draft: false

--- a/posts/2026-02-03-opencode-mcp-config-schema-ko.md
+++ b/posts/2026-02-03-opencode-mcp-config-schema-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "OpenCode vs Claude Desktop: MCP 설정 스키마 함정"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, configuration]
 tags: [opencode, mcp, claude-desktop, schema, configuration]
 draft: false

--- a/posts/2026-02-03-parallel-wave-execution-en.md
+++ b/posts/2026-02-03-parallel-wave-execution-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Wave-Based Task Orchestration: When Theoretical Parallelism Meets Reality"
 date: 2026-02-03
+author: Raoul
 categories: [architecture, ai-agents]
 tags: [orchestration, parallel-execution, task-planning, dependency-management]
 draft: false

--- a/posts/2026-02-03-parallel-wave-execution-ko.md
+++ b/posts/2026-02-03-parallel-wave-execution-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "웨이브 기반 태스크 오케스트레이션: 이론적 병렬성이 현실을 만날 때"
 date: 2026-02-03
+author: Raoul
 categories: [architecture, ai-agents]
 tags: [orchestration, parallel-execution, task-planning, dependency-management]
 draft: false

--- a/posts/2026-02-03-plan-agent-task-structure-en.md
+++ b/posts/2026-02-03-plan-agent-task-structure-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Structured Task Templates for AI Agent Delegation"
 date: 2026-02-03
+author: Raoul
 categories: [ai-agents, architecture]
 tags: [task-planning, delegation, prompt-engineering, ai-orchestration]
 draft: false

--- a/posts/2026-02-03-plan-agent-task-structure-ko.md
+++ b/posts/2026-02-03-plan-agent-task-structure-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "AI 에이전트 위임을 위한 구조화된 태스크 템플릿"
 date: 2026-02-03
+author: Raoul
 categories: [ai-agents, architecture]
 tags: [task-planning, delegation, prompt-engineering, ai-orchestration]
 draft: false

--- a/posts/2026-02-03-playwright-invisible-modal-en.md
+++ b/posts/2026-02-03-playwright-invisible-modal-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Playwright vs Invisible Modals: When Clicks Don't Click"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, automation]
 tags: [playwright, browser-automation, google, modal, testing]
 draft: false

--- a/posts/2026-02-03-playwright-invisible-modal-ko.md
+++ b/posts/2026-02-03-playwright-invisible-modal-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Playwright vs 보이지 않는 모달: 클릭이 클릭되지 않을 때"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, automation]
 tags: [playwright, browser-automation, google, modal, testing]
 draft: false

--- a/posts/2026-02-03-preflight-verification-pattern-en.md
+++ b/posts/2026-02-03-preflight-verification-pattern-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Preflight Verification: Never Get Locked Out of Your Server Again"
 date: 2026-02-03
+author: Raoul
 categories: [devops, security]
 tags: [firewall, ssh, safety, patterns, remote-management]
 draft: false

--- a/posts/2026-02-03-preflight-verification-pattern-ko.md
+++ b/posts/2026-02-03-preflight-verification-pattern-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "사전 검증 패턴: 서버에서 다시는 잠기지 않는 법"
 date: 2026-02-03
+author: Raoul
 categories: [devops, security]
 tags: [firewall, ssh, safety, patterns, remote-management]
 draft: false

--- a/posts/2026-02-03-project-rename-env-migration-en.md
+++ b/posts/2026-02-03-project-rename-env-migration-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The Hidden Pain of Project Renaming: Environment Variable Migration"
 date: 2026-02-03
+author: Raoul
 categories: [devops, debugging]
 tags: [migration, environment-variables, breaking-changes, project-management]
 draft: false

--- a/posts/2026-02-03-project-rename-env-migration-ko.md
+++ b/posts/2026-02-03-project-rename-env-migration-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "프로젝트 이름 변경의 숨겨진 고통: 환경 변수 마이그레이션"
 date: 2026-02-03
+author: Raoul
 categories: [devops, debugging]
 tags: [migration, environment-variables, breaking-changes, project-management]
 draft: false

--- a/posts/2026-02-03-reddit-public-json-api-en.md
+++ b/posts/2026-02-03-reddit-public-json-api-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Reddit OAuth Blocked? The Public JSON API Still Works"
 date: 2026-02-03
+author: Raoul
 categories: [api, workaround]
 tags: [reddit, api, scraping, oauth, public-api]
 draft: false

--- a/posts/2026-02-03-reddit-public-json-api-ko.md
+++ b/posts/2026-02-03-reddit-public-json-api-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Reddit OAuth 차단됨? Public JSON API는 여전히 작동한다"
 date: 2026-02-03
+author: Raoul
 categories: [api, workaround]
 tags: [reddit, api, scraping, oauth, public-api]
 draft: false

--- a/posts/2026-02-03-repo-separation-hugo-content-en.md
+++ b/posts/2026-02-03-repo-separation-hugo-content-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Separating Hugo Infrastructure from Content with Git Submodules"
 date: 2026-02-03
+author: Raoul
 categories: [architecture, blogging]
 tags: [hugo, git, obsidian, submodules, repo-management]
 draft: false

--- a/posts/2026-02-03-repo-separation-hugo-content-ko.md
+++ b/posts/2026-02-03-repo-separation-hugo-content-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Git 서브모듈로 Hugo 인프라와 콘텐츠 분리하기"
 date: 2026-02-03
+author: Raoul
 categories: [architecture, blogging]
 tags: [hugo, git, obsidian, submodules, repo-management]
 draft: false

--- a/posts/2026-02-03-submodule-ci-trigger-en.md
+++ b/posts/2026-02-03-submodule-ci-trigger-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Git Submodules Don't Trigger CI: The Webhook Gotcha"
 date: 2026-02-03
+author: Raoul
 categories: [devops, git]
 tags: [git-submodule, ci-cd, cloudflare, deployment]
 draft: false

--- a/posts/2026-02-03-submodule-ci-trigger-ko.md
+++ b/posts/2026-02-03-submodule-ci-trigger-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Git Submodule은 CI를 트리거하지 않는다: 웹훅 함정"
 date: 2026-02-03
+author: Raoul
 categories: [devops, git]
 tags: [git-submodule, ci-cd, cloudflare, deployment]
 draft: false

--- a/posts/2026-02-03-teresa-torres-ai-pipeline-en.md
+++ b/posts/2026-02-03-teresa-torres-ai-pipeline-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Building Your Own /today Command: A Teresa Torres Approach to Personal AI"
 date: 2026-02-03
+author: Raoul
 categories: [productivity, automation]
 tags: [ai-assistant, morning-routine, obsidian, automation, personal-productivity]
 draft: false

--- a/posts/2026-02-03-teresa-torres-ai-pipeline-ko.md
+++ b/posts/2026-02-03-teresa-torres-ai-pipeline-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "나만의 /today 명령어 만들기: Teresa Torres식 개인 AI 파이프라인"
 date: 2026-02-03
+author: Raoul
 categories: [productivity, automation]
 tags: [ai-assistant, morning-routine, obsidian, automation, personal-productivity]
 draft: false

--- a/posts/2026-02-03-three-zone-vm-security-en.md
+++ b/posts/2026-02-03-three-zone-vm-security-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Defense in Depth: A Three-Zone VM Architecture for Autonomous AI Agents"
 date: 2026-02-03
+author: Raoul
 categories: [security, architecture]
 tags: [ai-agents, vm, orbstack, isolation, security-architecture]
 draft: false

--- a/posts/2026-02-03-three-zone-vm-security-ko.md
+++ b/posts/2026-02-03-three-zone-vm-security-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "심층 방어: 자율 AI 에이전트를 위한 3-Zone VM 아키텍처"
 date: 2026-02-03
+author: Raoul
 categories: [security, architecture]
 tags: [ai-agents, vm, orbstack, isolation, security-architecture]
 draft: false

--- a/posts/2026-02-03-tmux-agent-recovery-en.md
+++ b/posts/2026-02-03-tmux-agent-recovery-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Never Lose AI Agent Progress: Tmux for Remote Sessions"
 date: 2026-02-03
+author: Raoul
 categories: [workflow, devops]
 tags: [tmux, ssh, ai-agents, remote-work, recovery]
 draft: false

--- a/posts/2026-02-03-tmux-agent-recovery-ko.md
+++ b/posts/2026-02-03-tmux-agent-recovery-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "AI 에이전트 진행상황 잃지 않기: 원격 세션을 위한 Tmux"
 date: 2026-02-03
+author: Raoul
 categories: [workflow, devops]
 tags: [tmux, ssh, ai-agents, remote-work, recovery]
 draft: false

--- a/posts/2026-02-03-tool-internal-crash-en.md
+++ b/posts/2026-02-03-tool-internal-crash-en.md
@@ -1,6 +1,7 @@
 ---
 title: "When Your Tool's Internals Crash: Debugging Third-Party Code"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, tooling]
 tags: [debugging, race-condition, cli-tools, error-handling]
 draft: false

--- a/posts/2026-02-03-tool-internal-crash-ko.md
+++ b/posts/2026-02-03-tool-internal-crash-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "도구 내부가 크래시할 때: 서드파티 코드 디버깅"
 date: 2026-02-03
+author: Raoul
 categories: [debugging, tooling]
 tags: [debugging, race-condition, cli-tools, error-handling]
 draft: false

--- a/posts/2026-02-03-user-scoped-firewall-rules-en.md
+++ b/posts/2026-02-03-user-scoped-firewall-rules-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Sandboxing AI Agents at the OS Level: User-Scoped Firewall Rules"
 date: 2026-02-03
+author: Raoul
 categories: [security, infrastructure]
 tags: [firewall, macos, pf, ai-agents, service-isolation]
 draft: false

--- a/posts/2026-02-03-user-scoped-firewall-rules-ko.md
+++ b/posts/2026-02-03-user-scoped-firewall-rules-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "OS 수준에서 AI 에이전트 샌드박싱: 사용자 범위 방화벽 규칙"
 date: 2026-02-03
+author: Raoul
 categories: [security, infrastructure]
 tags: [firewall, macos, pf, ai-agents, service-isolation]
 draft: false

--- a/posts/2026-02-04-agent-council-taste-through-forgetting-en.md
+++ b/posts/2026-02-04-agent-council-taste-through-forgetting-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Agent Council: Taste Through Forgetting"
 date: 2026-02-04
+author: Raoul
 categories: [AI, Architecture]
 tags: [ai-agents, architecture, decision-making]
 draft: false

--- a/posts/2026-02-04-agent-council-taste-through-forgetting-ko.md
+++ b/posts/2026-02-04-agent-council-taste-through-forgetting-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "에이전트 위원회: 망각을 통한 통찰의 정제"
 date: 2026-02-04
+author: Raoul
 categories: [AI, Architecture]
 tags: [ai-agents, architecture, decision-making]
 draft: false

--- a/posts/2026-02-04-ai-blog-series-3-meta.ko.md
+++ b/posts/2026-02-04-ai-blog-series-3-meta.ko.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [ai-blog-series, meta-content, ai-collaboration, workflow]
 draft: false
 summary: "작업 자체가 콘텐츠가 되는 메타 재귀적 발견, 그리고 AI와 협업하는 새로운 방식"
+lang: ko
 series: ["AI와 블로그 만들기"]
 cover:
   image: "/cover-series-3.png"

--- a/posts/2026-02-04-ai-blog-series-3-meta.md
+++ b/posts/2026-02-04-ai-blog-series-3-meta.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [ai-blog-series, meta-content, ai-collaboration, workflow]
 draft: false
 summary: "Why the process of building can become the content itself, and a new paradigm for AI collaboration."
+lang: en
 series: ["Building a Blog with AI"]
 cover:
   image: "/cover-series-3.png"

--- a/posts/2026-02-04-ai-security-audit-22-vulns-en.md
+++ b/posts/2026-02-04-ai-security-audit-22-vulns-en.md
@@ -1,6 +1,7 @@
 ---
 title: "22 Ways Your AI Agent Can Be Compromised: A Security Audit"
 date: 2026-02-04
+author: Raoul
 categories: [Security, AI]
 tags: [security, audit, ai-agents, vulnerabilities]
 draft: false

--- a/posts/2026-02-04-ai-security-audit-22-vulns-ko.md
+++ b/posts/2026-02-04-ai-security-audit-22-vulns-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "AI 에이전트가 해킹당하는 22가지 방법: 보안 감사 보고서"
 date: 2026-02-04
+author: Raoul
 categories: [Security, AI]
 tags: [security, audit, ai-agents, vulnerabilities]
 draft: false

--- a/posts/2026-02-04-auto-code-review-hook-en.md
+++ b/posts/2026-02-04-auto-code-review-hook-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Shift-Left with AI: Automatic Code Review via Hooks"
 date: 2026-02-04
+author: Raoul
 categories: [DevOps, AI]
 tags: [code-review, automation, hooks, opencode]
 draft: false

--- a/posts/2026-02-04-auto-code-review-hook-ko.md
+++ b/posts/2026-02-04-auto-code-review-hook-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "AI와 함께하는 Shift-Left: 훅(Hook)을 이용한 자동 코드 리뷰"
 date: 2026-02-04
+author: Raoul
 categories: [DevOps, AI]
 tags: [code-review, automation, hooks, opencode]
 draft: false

--- a/posts/2026-02-04-auto-harvest-enforcement-en.md
+++ b/posts/2026-02-04-auto-harvest-enforcement-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Never Lose an Insight Again: Auto-Harvesting AI Sessions"
 date: 2026-02-04
+author: Raoul
 categories: [Knowledge Management, AI]
 tags: [automation, content-creation, knowledge-management, opencode]
 draft: false

--- a/posts/2026-02-04-auto-harvest-enforcement-ko.md
+++ b/posts/2026-02-04-auto-harvest-enforcement-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "통찰을 놓치지 않는 법: AI 세션 자동 수확(Auto-Harvesting)"
 date: 2026-02-04
+author: Raoul
 categories: [Knowledge Management, AI]
 tags: [automation, content-creation, knowledge-management, opencode]
 draft: false

--- a/posts/2026-02-04-background-task-concurrency-limits-en.md
+++ b/posts/2026-02-04-background-task-concurrency-limits-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The Concurrency Trap: Why 22 AI Agents are Slower Than 5"
 date: 2026-02-04
+author: Raoul
 categories: [Performance, AI]
 tags: [ai-agents, performance, concurrency, opencode]
 draft: false

--- a/posts/2026-02-04-background-task-concurrency-limits-ko.md
+++ b/posts/2026-02-04-background-task-concurrency-limits-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "병렬성의 함정: 왜 22개의 AI 에이전트가 5개보다 느릴까?"
 date: 2026-02-04
+author: Raoul
 categories: [Performance, AI]
 tags: [ai-agents, performance, concurrency, opencode]
 draft: false

--- a/posts/2026-02-04-bash-32-compatibility-en.md
+++ b/posts/2026-02-04-bash-32-compatibility-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Bash 3.2: macOS's Secret Compatibility Trap"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [bash, macos, compatibility]
 draft: false

--- a/posts/2026-02-04-bash-32-compatibility-ko.md
+++ b/posts/2026-02-04-bash-32-compatibility-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Bash 3.2: macOS의 숨겨진 호환성 함정"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [bash, macos, compatibility]
 draft: false

--- a/posts/2026-02-04-batch-ai-cover-image-generation-en.md
+++ b/posts/2026-02-04-batch-ai-cover-image-generation-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Automating Blog Visuals: Batch Generating 29 AI Cover Images in Minutes"
 date: 2026-02-04
+author: Raoul
 categories: [AI, Automation]
 tags: [ai, images, automation, workflow]
 draft: false

--- a/posts/2026-02-04-batch-ai-cover-image-generation-ko.md
+++ b/posts/2026-02-04-batch-ai-cover-image-generation-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "블로그 비주얼 자동화: 3분 만에 29개의 AI 커버 이미지 생성하기"
 date: 2026-02-04
+author: Raoul
 categories: [AI, Automation]
 tags: [ai, images, automation, workflow]
 draft: false

--- a/posts/2026-02-04-before-model-select-hook-en.md
+++ b/posts/2026-02-04-before-model-select-hook-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Dynamic Model Routing: The Power of the before_model_select Hook"
 date: 2026-02-04
+author: Raoul
 categories: [AI, Architecture]
 tags: [plugin-architecture, hooks, model-routing, opencode]
 draft: false

--- a/posts/2026-02-04-before-model-select-hook-ko.md
+++ b/posts/2026-02-04-before-model-select-hook-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "동적 모델 라우팅: before_model_select 훅의 강력함"
 date: 2026-02-04
+author: Raoul
 categories: [AI, Architecture]
 tags: [plugin-architecture, hooks, model-routing, opencode]
 draft: false

--- a/posts/2026-02-04-cascading-model-fallback-en.md
+++ b/posts/2026-02-04-cascading-model-fallback-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The 90% Free AI Strategy: Cascading Model Fallback"
 date: 2026-02-04
+author: Raoul
 categories: [AI, Cost-Optimization]
 tags: [ai, model-routing, fallback, cost-optimization, moltbot]
 draft: false

--- a/posts/2026-02-04-cascading-model-fallback-ko.md
+++ b/posts/2026-02-04-cascading-model-fallback-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "90% 비용 절감 전략: 계층적 모델 폴백(Cascading Fallback)"
 date: 2026-02-04
+author: Raoul
 categories: [AI, Cost-Optimization]
 tags: [ai, model-routing, fallback, cost-optimization, moltbot]
 draft: false

--- a/posts/2026-02-04-env-var-naming-mismatch-en.md
+++ b/posts/2026-02-04-env-var-naming-mismatch-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The Environment Variable That Broke Everything: A Naming Migration Story"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [configuration, environment-variables]
 draft: false

--- a/posts/2026-02-04-env-var-naming-mismatch-ko.md
+++ b/posts/2026-02-04-env-var-naming-mismatch-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "모든 것을 망가뜨린 환경 변수: 네이밍 마이그레이션의 교훈"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [configuration, environment-variables]
 draft: false

--- a/posts/2026-02-04-golden-circle-blog-writing-en.md
+++ b/posts/2026-02-04-golden-circle-blog-writing-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The Golden Circle for Technical Writers: Why Your Blog Needs a 'Why'"
 date: 2026-02-04
+author: Raoul
 categories: [Writing, Productivity]
 tags: [writing, blog, storytelling]
 draft: false

--- a/posts/2026-02-04-golden-circle-blog-writing-ko.md
+++ b/posts/2026-02-04-golden-circle-blog-writing-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "기술 블로거를 위한 골든 서클: 왜 '왜(Why)'에서 시작해야 하는가"
 date: 2026-02-04
+author: Raoul
 categories: [Writing, Productivity]
 tags: [writing, blog, storytelling]
 draft: false

--- a/posts/2026-02-04-kimi-config-wrong-location-en.md
+++ b/posts/2026-02-04-kimi-config-wrong-location-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Why Your Config Changes Aren't Working: Templates vs. Active Configs"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [config, opencode]
 draft: false

--- a/posts/2026-02-04-kimi-config-wrong-location-ko.md
+++ b/posts/2026-02-04-kimi-config-wrong-location-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "설정 변경이 적용되지 않는 이유: 템플릿과 활성 설정의 차이"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [config, opencode]
 draft: false

--- a/posts/2026-02-04-korean-translation-missing-from-batch-en.md
+++ b/posts/2026-02-04-korean-translation-missing-from-batch-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The Commit I Had to Make Twice: A Lesson in Bilingual Content Management"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [i18n, automation, git]
 draft: false

--- a/posts/2026-02-04-korean-translation-missing-from-batch-ko.md
+++ b/posts/2026-02-04-korean-translation-missing-from-batch-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "두 번 커밋해야 했던 이유: 다국어 콘텐츠 관리의 교훈"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [i18n, automation, git]
 draft: false

--- a/posts/2026-02-04-multi-zone-ai-security-architecture-en.md
+++ b/posts/2026-02-04-multi-zone-ai-security-architecture-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Defense in Depth: A 3-Zone Security Architecture for AI Agents"
 date: 2026-02-04
+author: Raoul
 categories: [Security, AI]
 tags: [security, architecture, ai-agents, defense-in-depth, moltbot]
 draft: false

--- a/posts/2026-02-04-multi-zone-ai-security-architecture-ko.md
+++ b/posts/2026-02-04-multi-zone-ai-security-architecture-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "심층 방어: AI 에이전트를 위한 3구역 보안 아키텍처"
 date: 2026-02-04
+author: Raoul
 categories: [Security, AI]
 tags: [security, architecture, ai-agents, defense-in-depth, moltbot]
 draft: false

--- a/posts/2026-02-04-naming-unification-migration-en.md
+++ b/posts/2026-02-04-naming-unification-migration-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Unified Naming Migration: Eradicating Technical Debt with Pre-commit Hooks"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, DevOps]
 tags: [refactoring, migration, technical-debt, automation]
 draft: false

--- a/posts/2026-02-04-naming-unification-migration-ko.md
+++ b/posts/2026-02-04-naming-unification-migration-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "통합 네이밍 마이그레이션: 프리커밋 훅으로 기술 부채 뿌리 뽑기"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, DevOps]
 tags: [refactoring, migration, technical-debt, automation]
 draft: false

--- a/posts/2026-02-04-opencode-plugin-zod-version-mismatch-en.md
+++ b/posts/2026-02-04-opencode-plugin-zod-version-mismatch-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The Zod Version Trap: Debugging OpenCode Plugin Compatibility"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, OpenCode]
 tags: [opencode, plugins, zod, typescript, debugging]
 draft: false

--- a/posts/2026-02-04-opencode-plugin-zod-version-mismatch-ko.md
+++ b/posts/2026-02-04-opencode-plugin-zod-version-mismatch-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Zod 버전의 함정: OpenCode 플러그인 호환성 디버깅"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, OpenCode]
 tags: [opencode, plugins, zod, typescript, debugging]
 draft: false

--- a/posts/2026-02-04-opencode-tilde-expansion-en.md
+++ b/posts/2026-02-04-opencode-tilde-expansion-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The Tilde Trap: Why OpenCode Configs Need Absolute Paths"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [opencode, configuration, paths]
 draft: false

--- a/posts/2026-02-04-opencode-tilde-expansion-ko.md
+++ b/posts/2026-02-04-opencode-tilde-expansion-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "물결표(~)의 함정: OpenCode 설정에 절대 경로가 필요한 이유"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [opencode, configuration, paths]
 draft: false

--- a/posts/2026-02-04-shell-completion-caching-en.md
+++ b/posts/2026-02-04-shell-completion-caching-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Speed Up Your Shell Startup: The Case for Completion Caching"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, Performance]
 tags: [shell, performance, cli, productivity]
 draft: false

--- a/posts/2026-02-04-shell-completion-caching-ko.md
+++ b/posts/2026-02-04-shell-completion-caching-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "터미널 시작 속도 올리기: 쉘 완성(Completion) 캐싱의 필요성"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, Performance]
 tags: [shell, performance, cli, productivity]
 draft: false

--- a/posts/2026-02-04-skill-automation-framework-en.md
+++ b/posts/2026-02-04-skill-automation-framework-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Building a Skill-Based AI Automation Framework"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, AI]
 tags: [automation, skills, ai-agents, framework, architecture]
 draft: false

--- a/posts/2026-02-04-skill-automation-framework-ko.md
+++ b/posts/2026-02-04-skill-automation-framework-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "스킬 기반 AI 자동화 프레임워크 구축하기"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, AI]
 tags: [automation, skills, ai-agents, framework, architecture]
 draft: false

--- a/posts/2026-02-04-toctou-rate-limiting-en.md
+++ b/posts/2026-02-04-toctou-rate-limiting-en.md
@@ -1,6 +1,7 @@
 ---
 title: "TOCTOU Race Conditions in Rate Limiting: A Security Deep Dive"
 date: 2026-02-04
+author: Raoul
 categories: [security, debugging]
 tags: [toctou, race-condition, rate-limiting, concurrency, security]
 draft: false

--- a/posts/2026-02-04-toctou-rate-limiting-ko.md
+++ b/posts/2026-02-04-toctou-rate-limiting-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Rate Limiting의 TOCTOU 레이스 컨디션: 보안 심층 분석"
 date: 2026-02-04
+author: Raoul
 categories: [security, debugging]
 tags: [toctou, race-condition, rate-limiting, concurrency, security]
 draft: false

--- a/posts/2026-02-04-try-shell-experiment-directories-en.md
+++ b/posts/2026-02-04-try-shell-experiment-directories-en.md
@@ -1,6 +1,7 @@
 ---
 title: "The 'try' Command: Frictionless Experimentation in Your Shell"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, Workflow]
 tags: [shell, workflow, productivity, dev-setup]
 draft: false

--- a/posts/2026-02-04-try-shell-experiment-directories-ko.md
+++ b/posts/2026-02-04-try-shell-experiment-directories-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "'try' 명령어: 쉘에서의 마찰 없는 실험 환경 구축"
 date: 2026-02-04
+author: Raoul
 categories: [Engineering, Workflow]
 tags: [shell, workflow, productivity, dev-setup]
 draft: false

--- a/posts/2026-02-04-zod-import-plugin-crash-en.md
+++ b/posts/2026-02-04-zod-import-plugin-crash-en.md
@@ -1,6 +1,7 @@
 ---
 title: "Why Importing Zod Directly Crashes OpenCode Plugins"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [opencode, zod, plugin, typescript, debugging]
 draft: false

--- a/posts/2026-02-04-zod-import-plugin-crash-ko.md
+++ b/posts/2026-02-04-zod-import-plugin-crash-ko.md
@@ -1,6 +1,7 @@
 ---
 title: "Zod를 직접 임포트하면 OpenCode 플러그인이 크래시되는 이유"
 date: 2026-02-04
+author: Raoul
 categories: [debugging, lessons-learned]
 tags: [opencode, zod, plugin, typescript, debugging]
 draft: false

--- a/posts/2026-02-05-ai-blog-series-4-automation.ko.md
+++ b/posts/2026-02-05-ai-blog-series-4-automation.ko.md
@@ -6,9 +6,10 @@ categories: [meta]
 tags: [ai-blog-series, opencode, automation, skills, mcp, tooling]
 draft: false
 summary: "작업의 흐름을 방해하지 않으면서도, AI가 곁에서 아이디어를 자동으로 기록하게 만드는 기술적인 설정에 대해 공유합니다."
+lang: ko
 series: ["Building a Blog with AI"]
 cover:
-  image: "/cover-series-4.png"
+  image: "/covers/cover-2026-02-05-ai-blog-series-4-automation.png"
   alt: "톱니바퀴 아이콘이 있는 클래퍼보드"
 ---
 

--- a/posts/2026-02-05-ai-blog-series-4-automation.md
+++ b/posts/2026-02-05-ai-blog-series-4-automation.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [ai-blog-series, opencode, automation, skills, mcp, tooling]
 draft: false
 summary: "Why I automated knowledge capture, and the technical setup that lets AI record ideas while I work."
+lang: en
 cover:
   image: "/covers/cover-2026-02-05-ai-blog-series-4-automation.png"
 series: ["Building a Blog with AI"]

--- a/posts/2026-02-06-ai-blog-series-5-transformation.ko.md
+++ b/posts/2026-02-06-ai-blog-series-5-transformation.ko.md
@@ -6,9 +6,10 @@ categories: [meta]
 tags: [ai-blog-series, content-creation, writing-process, workflow]
 draft: false
 summary: "날것의 생각이 마찰을 줄인 개발 과정을 거쳐 어떻게 완성된 글로 변하는지에 대하여."
+lang: ko
 series: ["Building a Blog with AI"]
 cover:
-  image: "/cover-series-5.png"
+  image: "/covers/cover-2026-02-06-ai-blog-series-5-transformation.png"
   alt: "새싹과 꽃이 있는 클래퍼보드"
 ---
 

--- a/posts/2026-02-06-ai-blog-series-5-transformation.md
+++ b/posts/2026-02-06-ai-blog-series-5-transformation.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [ai-blog-series, content-creation, writing-process, workflow]
 draft: false
 summary: "Why the gap between thought and article kills most ideas, and how dialogue with AI bridges it."
+lang: en
 cover:
   image: "/covers/cover-2026-02-06-ai-blog-series-5-transformation.png"
 series: ["Building a Blog with AI"]

--- a/posts/2026-02-07-process-is-content.ko.md
+++ b/posts/2026-02-07-process-is-content.ko.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [meta, content-creation, AI, workflow]
 draft: false
 summary: "'일하는 것'과 '일에 대해 쓰는 것'을 분리하지 마라. AI와 함께 일할 때, 대화 그 자체가 콘텐츠다."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-07-process-is-content.png"
 ---

--- a/posts/2026-02-07-process-is-content.md
+++ b/posts/2026-02-07-process-is-content.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [meta, content-creation, AI, workflow]
 draft: false
 summary: "Stop separating 'the work' from 'writing about the work.' When you work with AI, the conversation itself is the content."
+lang: en
 cover:
   image: "/covers/cover-2026-02-07-process-is-content.png"
 ---

--- a/posts/2026-02-07-secure-api-keys-macos-keychain.ko.md
+++ b/posts/2026-02-07-secure-api-keys-macos-keychain.ko.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [security, macos, keychain, api-keys, secrets-management]
 draft: false
 summary: "API 키는 셸 설정 파일에 있으면 안 된다. 필요할 때만 키체인에서 시크릿을 가져오는 래퍼 패턴을 소개한다."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-07-secure-api-keys-macos-keychain.png"
 ---

--- a/posts/2026-02-07-secure-api-keys-macos-keychain.md
+++ b/posts/2026-02-07-secure-api-keys-macos-keychain.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [security, macos, keychain, api-keys, secrets-management]
 draft: false
 summary: "Your API keys don't belong in shell config files. Here's a wrapper pattern that fetches secrets from Keychain only when needed."
+lang: en
 cover:
   image: "/covers/cover-2026-02-07-secure-api-keys-macos-keychain.png"
 ---

--- a/posts/2026-02-08-invert-documentation-burden.ko.md
+++ b/posts/2026-02-08-invert-documentation-burden.ko.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [workflow, AI, automation, content-creation]
 draft: false
 summary: "수동으로 작업을 문서화하지 마라. 당신이 실제 생각에 집중하는 동안 AI가 조용히 통찰, 결정, 실수를 캡처하도록 설정하라."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-08-invert-documentation-burden.png"
 ---

--- a/posts/2026-02-08-invert-documentation-burden.md
+++ b/posts/2026-02-08-invert-documentation-burden.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [workflow, AI, automation, content-creation]
 draft: false
 summary: "Stop documenting your work manually. Configure AI to silently capture insights, decisions, and mistakes while you focus on actual thinking."
+lang: en
 cover:
   image: "/covers/cover-2026-02-08-invert-documentation-burden.png"
 ---

--- a/posts/2026-02-08-personal-today-command.ko.md
+++ b/posts/2026-02-08-personal-today-command.ko.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [workflow, automation, productivity, morning-routine, ai-assistant]
 draft: false
 summary: "Teresa Torres에서 영감을 받아, 캘린더, 이메일, 뉴스레터를 하나의 데일리 브리핑 문서로 가져오는 단일 명령어를 만들었다—그리고 모든 곳에 동기화한다."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-08-personal-today-command.png"
 ---

--- a/posts/2026-02-08-personal-today-command.md
+++ b/posts/2026-02-08-personal-today-command.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [workflow, automation, productivity, morning-routine, ai-assistant]
 draft: false
 summary: "Inspired by Teresa Torres, I built a single command that pulls my calendar, email, and newsletters into a daily briefing document—then syncs it everywhere."
+lang: en
 cover:
   image: "/covers/cover-2026-02-08-personal-today-command.png"
 ---

--- a/posts/2026-02-08-wave-based-task-orchestration.ko.md
+++ b/posts/2026-02-08-wave-based-task-orchestration.ko.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [ai-orchestration, parallel-execution, task-planning, dependency-management]
 draft: false
 summary: "복잡한 작업을 의존성 인식 웨이브로 나누면 여러 AI 에이전트가 동시에 작업할 수 있다—하지만 이론적 병렬성이 항상 실제 실행과 일치하지는 않는다."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-08-wave-based-task-orchestration.png"
 ---

--- a/posts/2026-02-08-wave-based-task-orchestration.md
+++ b/posts/2026-02-08-wave-based-task-orchestration.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [ai-orchestration, parallel-execution, task-planning, dependency-management]
 draft: false
 summary: "Breaking complex tasks into dependency-aware waves lets multiple AI agents work simultaneously—but theoretical parallelism doesn't always match practical execution."
+lang: en
 cover:
   image: "/covers/cover-2026-02-08-wave-based-task-orchestration.png"
 ---

--- a/posts/2026-02-09-auto-loading-ai-skills.ko.md
+++ b/posts/2026-02-09-auto-loading-ai-skills.ko.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [opencode, configuration, skills, automation]
 draft: false
 summary: "AI 스킬을 수동으로 호출하지 마라. 자동 로드되도록 설정해서, 일회성 명령을 지속적인 백그라운드 행동으로 바꿔라."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-09-auto-loading-ai-skills.png"
 ---

--- a/posts/2026-02-09-auto-loading-ai-skills.md
+++ b/posts/2026-02-09-auto-loading-ai-skills.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [opencode, configuration, skills, automation]
 draft: false
 summary: "Stop invoking AI skills manually. Configure them to auto-load, turning one-off commands into persistent background behaviors."
+lang: en
 cover:
   image: "/covers/cover-2026-02-09-auto-loading-ai-skills.png"
 ---

--- a/posts/2026-02-10-phased-docker-sandbox-testing.ko.md
+++ b/posts/2026-02-10-phased-docker-sandbox-testing.ko.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [docker, sandbox, security, testing, automation]
 draft: false
 summary: "AI 봇이 문자를 보내고 실제 파일에 접근할 수 있을 때, 실제 데이터를 날리지 않고 샌드박스를 어떻게 테스트하나? 4단계 접근법."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-10-phased-docker-sandbox-testing.png"
 ---

--- a/posts/2026-02-10-phased-docker-sandbox-testing.md
+++ b/posts/2026-02-10-phased-docker-sandbox-testing.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [docker, sandbox, security, testing, automation]
 draft: false
 summary: "When your AI bot can send texts and access real files, how do you test the sandbox without blowing up your actual data? A four-phase approach."
+lang: en
 cover:
   image: "/covers/cover-2026-02-10-phased-docker-sandbox-testing.png"
 ---

--- a/posts/2026-02-12-one-obsidian-vault-for-everything.ko.md
+++ b/posts/2026-02-12-one-obsidian-vault-for-everything.ko.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [knowledge-management, obsidian, workflow, centralization]
 draft: false
 summary: "노트를 여러 위치에 흩뜨리지 마라. 모든 것—시드, 초안, 포스트—을 담은 단일 Obsidian 볼트가 달리는 절대 보지 못할 연결을 만든다."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-12-one-obsidian-vault-for-everything.png"
 ---

--- a/posts/2026-02-12-one-obsidian-vault-for-everything.md
+++ b/posts/2026-02-12-one-obsidian-vault-for-everything.md
@@ -6,6 +6,7 @@ categories: [meta]
 tags: [knowledge-management, obsidian, workflow, centralization]
 draft: false
 summary: "Stop fragmenting your notes across locations. A single Obsidian vault with everything—seeds, drafts, posts—creates connections you'd never see otherwise."
+lang: en
 cover:
   image: "/covers/cover-2026-02-12-one-obsidian-vault-for-everything.png"
 ---

--- a/posts/2026-02-13-structured-task-definition-ai-agents.ko.md
+++ b/posts/2026-02-13-structured-task-definition-ai-agents.ko.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [ai-planning, task-structure, delegation, prompt-engineering]
 draft: false
 summary: "모호한 작업 설명은 모호한 결과를 낳는다. 구조화된 템플릿이 AI 에이전트가 자율 실행에 필요한 모든 것을 갖추게 한다."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-13-structured-task-definition-ai-agents.png"
 ---

--- a/posts/2026-02-13-structured-task-definition-ai-agents.md
+++ b/posts/2026-02-13-structured-task-definition-ai-agents.md
@@ -6,6 +6,7 @@ categories: [technical]
 tags: [ai-planning, task-structure, delegation, prompt-engineering]
 draft: false
 summary: "Vague task descriptions produce vague results. A structured template ensures AI agents have everything needed for autonomous execution."
+lang: en
 cover:
   image: "/covers/cover-2026-02-13-structured-task-definition-ai-agents.png"
 ---

--- a/posts/2026-02-14-bash-increment-gotcha.ko.md
+++ b/posts/2026-02-14-bash-increment-gotcha.ko.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [bash, gotcha, set-e, arithmetic]
 draft: false
 summary: "테스트 스크립트가 첫 번째 통과 테스트 후 조용히 죽었다. 범인: set -e와 결합된 ((var++))."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-14-bash-increment-gotcha.png"
 ---

--- a/posts/2026-02-14-bash-increment-gotcha.md
+++ b/posts/2026-02-14-bash-increment-gotcha.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [bash, gotcha, set-e, arithmetic]
 draft: false
 summary: "My test script died silently after the first passing test. The culprit: ((var++)) combined with set -e."
+lang: en
 cover:
   image: "/covers/cover-2026-02-14-bash-increment-gotcha.png"
 ---

--- a/posts/2026-02-14-symlink-absolute-path-trap.ko.md
+++ b/posts/2026-02-14-symlink-absolute-path-trap.ko.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [symlink, path, migration, hugo]
 draft: false
 summary: "Hugo 블로그가 포스트 0개를 보여줬다. 콘텐츠는 있었다—이 머신에 존재하지 않는 사용자를 가리키고 있었을 뿐."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-14-symlink-absolute-path-trap.png"
 ---

--- a/posts/2026-02-14-symlink-absolute-path-trap.md
+++ b/posts/2026-02-14-symlink-absolute-path-trap.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [symlink, path, migration, hugo]
 draft: false
 summary: "My Hugo blog showed zero posts. The content was there—just pointed at a user who doesn't exist on this machine."
+lang: en
 cover:
   image: "/covers/cover-2026-02-14-symlink-absolute-path-trap.png"
 ---

--- a/posts/2026-02-15-env-var-naming-migration.ko.md
+++ b/posts/2026-02-15-env-var-naming-migration.ko.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [migration, env-vars, naming, breaking-change]
 draft: false
 summary: "게이트웨이가 'env var 없음'으로 실패했다. 토큰은 있었다—옛 프로젝트 이름으로만."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-15-env-var-naming-migration.png"
 ---

--- a/posts/2026-02-15-env-var-naming-migration.md
+++ b/posts/2026-02-15-env-var-naming-migration.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [migration, env-vars, naming, breaking-change]
 draft: false
 summary: "The gateway failed with 'missing env var.' I had the token—just under the old project name."
+lang: en
 cover:
   image: "/covers/cover-2026-02-15-env-var-naming-migration.png"
 ---

--- a/posts/2026-02-16-playwright-auth-mismatch.ko.md
+++ b/posts/2026-02-16-playwright-auth-mismatch.ko.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [playwright, auth, integration-bug, mismatch]
 draft: false
 summary: "브라우저 인증 플로우를 완료했다. 스크립트는 여전히 'Auth required'라고 했다. 셸 래퍼와 TypeScript 구현이 '인증됨'이 무엇을 의미하는지에 대해 동의하지 않았다."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-16-playwright-auth-mismatch.png"
 ---

--- a/posts/2026-02-16-playwright-auth-mismatch.md
+++ b/posts/2026-02-16-playwright-auth-mismatch.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [playwright, auth, integration-bug, mismatch]
 draft: false
 summary: "I completed the browser auth flow. The script still said 'Auth required.' The shell wrapper and TypeScript implementation disagreed about what 'authenticated' meant."
+lang: en
 cover:
   image: "/covers/cover-2026-02-16-playwright-auth-mismatch.png"
 ---

--- a/posts/2026-02-17-mcp-config-schema-error.ko.md
+++ b/posts/2026-02-17-mcp-config-schema-error.ko.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [opencode, mcp, configuration]
 draft: false
 summary: "MCP 서버 설정이 Claude Desktop에서 작동했다. OpenCode에서는 검증에 실패했다. 같은 프로토콜, 다른 스키마."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-17-mcp-config-schema-error.png"
 ---

--- a/posts/2026-02-17-mcp-config-schema-error.md
+++ b/posts/2026-02-17-mcp-config-schema-error.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [opencode, mcp, configuration]
 draft: false
 summary: "My MCP server config worked in Claude Desktop. It failed validation in OpenCode. Same protocol, different schemas."
+lang: en
 cover:
   image: "/covers/cover-2026-02-17-mcp-config-schema-error.png"
 ---

--- a/posts/2026-02-18-model-id-mismatch.ko.md
+++ b/posts/2026-02-18-model-id-mismatch.ko.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [opencode, oh-my-opencode, configuration]
 draft: false
 summary: "OpenCode가 'ProviderModelNotFoundError'로 실패했다. 모델 ID는 존재했다—내 설정이 적은 것과 다르게만."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-18-model-id-mismatch.png"
 ---

--- a/posts/2026-02-18-model-id-mismatch.md
+++ b/posts/2026-02-18-model-id-mismatch.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [opencode, oh-my-opencode, configuration]
 draft: false
 summary: "OpenCode failed with 'ProviderModelNotFoundError.' The model ID existed—just not spelled the way my config spelled it."
+lang: en
 cover:
   image: "/covers/cover-2026-02-18-model-id-mismatch.png"
 ---

--- a/posts/2026-02-19-google-modal-overlay-blocking.ko.md
+++ b/posts/2026-02-19-google-modal-overlay-blocking.ko.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [playwright, google-ui, automation, modal]
 draft: false
 summary: "버튼이 보였다. 셀렉터가 찾았다. 클릭은 아무것도 안 했다. 보이지 않는 모달 오버레이가 모든 상호작용을 훔치고 있었다."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-19-google-modal-overlay-blocking.png"
 ---

--- a/posts/2026-02-19-google-modal-overlay-blocking.md
+++ b/posts/2026-02-19-google-modal-overlay-blocking.md
@@ -6,6 +6,7 @@ categories: [debugging]
 tags: [playwright, google-ui, automation, modal]
 draft: false
 summary: "The button was visible. The selector found it. The click did nothing. An invisible modal overlay was stealing every interaction."
+lang: en
 cover:
   image: "/covers/cover-2026-02-19-google-modal-overlay-blocking.png"
 ---

--- a/posts/2026-02-20-anatomy-good-system-design-prompt.ko.md
+++ b/posts/2026-02-20-anatomy-good-system-design-prompt.ko.md
@@ -6,6 +6,7 @@ categories: [ai-prompting]
 tags: [system-design, content-workflow, meta]
 draft: false
 summary: "한 문장이 전체 콘텐츠 캡처 시스템을 시작했다. 모호하게 들리는 프롬프트가 놀랍도록 효과적이었던 이유 분석."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-20-anatomy-good-system-design-prompt.png"
 ---

--- a/posts/2026-02-20-anatomy-good-system-design-prompt.md
+++ b/posts/2026-02-20-anatomy-good-system-design-prompt.md
@@ -6,6 +6,7 @@ categories: [ai-prompting]
 tags: [system-design, content-workflow, meta]
 draft: false
 summary: "One sentence launched an entire content capture system. Breaking down what made a vague-sounding prompt surprisingly effective."
+lang: en
 cover:
   image: "/covers/cover-2026-02-20-anatomy-good-system-design-prompt.png"
 ---

--- a/posts/2026-02-21-wong-kar-wai-color-grading-cloudinary.ko.md
+++ b/posts/2026-02-21-wong-kar-wai-color-grading-cloudinary.ko.md
@@ -6,6 +6,7 @@ categories: [ai-prompting]
 tags: [cloudinary, image-processing, css, film-aesthetic]
 draft: false
 summary: "포토샵 없음. 로컬 이미지 편집 없음. 스톡 사진을 무디한 홍콩 시네마로 바꾸는 CDN 변환만."
+lang: ko
 cover:
   image: "/covers/cover-2026-02-21-wong-kar-wai-color-grading-cloudinary.png"
 ---

--- a/posts/2026-02-21-wong-kar-wai-color-grading-cloudinary.md
+++ b/posts/2026-02-21-wong-kar-wai-color-grading-cloudinary.md
@@ -6,6 +6,7 @@ categories: [ai-prompting]
 tags: [cloudinary, image-processing, css, film-aesthetic]
 draft: false
 summary: "No Photoshop. No local image editing. Just CDN transforms that turn stock photos into moody Hong Kong cinema."
+lang: en
 cover:
   image: "/covers/cover-2026-02-21-wong-kar-wai-color-grading-cloudinary.png"
 ---

--- a/posts/2026-02-22-multi-feature-ultrawork-prompt.ko.md
+++ b/posts/2026-02-22-multi-feature-ultrawork-prompt.ko.md
@@ -6,6 +6,7 @@ categories: [ai-prompting]
 tags: [ultrawork, multi-feature, git-workflow, plugin-development]
 draft: false
 summary: "네 기능, 하나의 프롬프트, 명확화 제로. 손 잡아주기가 필요 없는 멀티 기능 요청 구조화 방법."
+lang: ko
 cover:
   image: "/covers/cover-ultrawork.png"
 ---

--- a/posts/2026-02-22-multi-feature-ultrawork-prompt.md
+++ b/posts/2026-02-22-multi-feature-ultrawork-prompt.md
@@ -6,6 +6,7 @@ categories: [ai-prompting]
 tags: [ultrawork, multi-feature, git-workflow, plugin-development]
 draft: false
 summary: "Four features, one prompt, zero clarifications. How to structure multi-feature requests that don't need hand-holding."
+lang: en
 cover:
   image: "/covers/cover-ultrawork.png"
 ---


### PR DESCRIPTION
## Summary
- Add missing `author` field to posts without author metadata
- Add missing `lang` field where not specified
- Fix 2 cover image paths that were incorrectly formatted

## Changes
- 152 post files updated with complete metadata
- All posts now have author and lang fields for proper rendering
- Cover image paths corrected for proper asset linking

## Testing & Verification
- [x] All post files have valid YAML front matter
- [x] Author field present on all posts
- [x] Lang field present on all posts
- [x] Cover image paths follow correct format
- [x] No syntax errors in markdown files

## Related Issue
Closes #7